### PR TITLE
Fix wrong dynamic link when target is mips-unknown-linux-musl

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,3 @@
+[target.mips-unknown-linux-musl]
+linker = "mips-linux-musl-gcc"
+rustflags = ["-C", "target-feature=+crt-static", "-C", "link-arg=-s"]

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,7 +1,0 @@
-[build]
-default-target="mips-unknown-linux-musl"
-
-[target.mips-unknown-linux-musl.env]
-passthrough = [
-    "RUST_BACKTRACE=1"
-]

--- a/README.md
+++ b/README.md
@@ -18,13 +18,18 @@ you can get more details by typing -h:
 cargo run -- -h
 ```
 
-You can make cross-compile to mips like this:
+## Cross Compile
 
+1. Add mips-unknown-linux-musl supports:
 ```shell
-cross build --release -v --no-default-features --features from_file
+rustup target add mips-unknown-linux-musl
 ```
-
-And find the bin at:
+2. Download musl toolchain from [musl.cc](https://musl.cc): mips-linux-musl-cross
+3. Release:
+```shell
+cargo build --target mips-unknown-linux-musl --release --no-default-features --features from_file
+```
+4. Find the bin:
 ```text
 target\mips-unknown-linux-musl\release
 ```


### PR DESCRIPTION
related issue:

https://github.com/rust-lang/rust/issues/80693

Close #3